### PR TITLE
Add storefront GraphQL proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Shopify Storefront Proxy
+
+This repository exposes a simple API endpoint that forwards GraphQL queries to the Shopify Storefront API. The endpoint is implemented as a Vercel/Next.js API route in `pages/api/storefront-graphql.js`.
+
+## Running locally
+
+1. Install dependencies:
+
+```bash
+npm install
+```
+
+2. Set the required environment variable in a `.env` file or your shell:
+
+```bash
+export SHOPIFY_STOREFRONT_ACCESS_TOKEN=your_storefront_token
+```
+
+3. Start the development server with Vercel (or `next dev` if you have Next.js installed):
+
+```bash
+npx vercel dev
+```
+
+The API will be available at `http://localhost:3000/api/storefront-graphql`.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "shopify-mcp",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "node-fetch": "^3.3.2"
+  }
+}

--- a/pages/api/storefront-graphql.js
+++ b/pages/api/storefront-graphql.js
@@ -1,0 +1,27 @@
+const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch(...args));
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const endpoint = 'https://e14290-mr.myshopify.com/api/2023-07/graphql.json';
+  try {
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Shopify-Storefront-Access-Token': process.env.SHOPIFY_STOREFRONT_ACCESS_TOKEN,
+      },
+      body: JSON.stringify(req.body),
+    });
+
+    const data = await response.json();
+    res.status(response.ok ? 200 : response.status).json(data);
+  } catch (error) {
+    console.error('Proxy error:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+}


### PR DESCRIPTION
## Summary
- add API route to proxy Storefront GraphQL calls
- declare `node-fetch` dependency
- document local development steps

## Testing
- `npm install --silent` *(fails: registry blocked)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688b6144db048326bf1ea89a87956442